### PR TITLE
Add private_cakeday_show_age_inline setting to toggle inline age on user cards

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/user-card-post-names/user-card-cakeday.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-card-post-names/user-card-cakeday.hbs
@@ -17,4 +17,6 @@
     <EmojiImages @list={{siteSettings.private_cakeday_emoji}} @title={{cakedayTitle}} />
   {{/if}}
 {{/if}}
-{{user-age-title userage=userAgeTitle title=userBirthdateTitle}}
+{{#if siteSettings.private_cakeday_show_age_inline}}
+  {{user-age-title userage=userAgeTitle title=userBirthdateTitle}}
+{{/if}}

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,6 +4,7 @@ en:
     private_cakeday_birthday_celebrate: "Celebrate birthdays by default"
     private_cakeday_birthday_required: "Birthdate is Required for all users"
     private_cakeday_birthday_show_year: "Show cakeday year selector, to allow users to input their age."
+    private_cakeday_show_age_inline: "Show the user's age inline beside their name on user cards. Disable this if another plugin already renders the age (e.g. discourse-custom-ap-profile) to avoid a duplicate age."
     private_cakeday_birthday_formatdmy: "Show cakeday selectors as DD-MM-YYYY, instead of MM-DD-YYYY"
     private_cakeday_emoji: "The emoji[s] that will be shown beside the user's name on the date that they joined Discourse. Multiple emojis can be specified by: smile|cake|smile"
     private_cakeday_birthday_enabled: "Show birthday emoji[s] beside the user's name on their birthday."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,9 @@ plugins:
   private_cakeday_birthday_show_year:
     default: false
     client: true
+  private_cakeday_show_age_inline:
+    default: true
+    client: true
   private_cakeday_birthday_formatdmy:
     default: false
     client: true


### PR DESCRIPTION
## Summary

- Adds a new client site setting `private_cakeday_show_age_inline` (default `true`).
- Guards the inline `{{user-age-title}}` output on the `user-card-post-names` connector behind the setting.
- Default `true` preserves existing behaviour for all current installs — no migration or visible change unless explicitly disabled.

## Why

The connector unconditionally renders the user's age inline beside their name on user cards. When another plugin also renders the age (e.g. `discourse-custom-ap-profile`, which has its own age display), the age appears **twice** on the same user card.

There was previously no clean way to suppress one of them without a site-specific CSS override. This setting lets an admin disable the cakeday plugin's inline age when a second plugin is the canonical age source.

## Changes

- `config/settings.yml` — new `private_cakeday_show_age_inline` (default `true`, `client: true`)
- `config/locales/server.en.yml` — setting description
- `assets/javascripts/discourse/templates/connectors/user-card-post-names/user-card-cakeday.hbs` — wrap the `{{user-age-title}}` line in `{{#if siteSettings.private_cakeday_show_age_inline}}`

## Test plan

- [ ] With the setting at its default (`true`), the inline age still shows on user cards as before.
- [ ] Set `private_cakeday_show_age_inline` to `false` in Admin → Settings → "private cakeday"; the inline age no longer renders on user cards.
- [ ] Cakeday/birthday emoji behaviour is unaffected in both states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)