### PR TITLE
Fix cakeday navigation, empty lists, and birthday load-more loop

### DIFF
--- a/app/controllers/discourse_private_cakeday/birthdays_controller.rb
+++ b/app/controllers/discourse_private_cakeday/birthdays_controller.rb
@@ -3,13 +3,10 @@
 module DiscoursePrivateCakeday
   class BirthdaysController < CakedayController
     before_action :ensure_birthday_enabled
+    before_action :restrict_to_celebrated_for_non_staff
 
     def index
       users, total, more_params = cakedays_by("date_of_birth")
-
-      if (!current_user.staff?)
-        users = users.where(id: (UserCustomField.where(name: "show_birthday_to_be_celebrated").where(value: "true").pluck(:user_id)))
-      end
 
       render_json_dump(
         birthdays: serialize_data(users, CakedayUserSerializer),
@@ -19,6 +16,21 @@ module DiscoursePrivateCakeday
     end
 
     private
+
+    # Non-staff users may only see members who opted in to having their
+    # birthday celebrated. This must narrow the set *before* cakedays_by
+    # counts and paginates, otherwise total_rows_birthdays disagrees with
+    # the rows actually returned and the client LoadMore loops forever.
+    def restrict_to_celebrated_for_non_staff
+      return if current_user.staff?
+
+      celebrated_user_ids =
+        UserCustomField.where(name: "show_birthday_to_be_celebrated", value: "true").select(
+          :user_id,
+        )
+
+      @users = @users.where(id: celebrated_user_ids)
+    end
 
     def ensure_birthday_enabled
       raise Discourse::NotFound if !SiteSetting.private_cakeday_birthday_enabled

--- a/assets/javascripts/discourse/components/user-info-list.hbs
+++ b/assets/javascripts/discourse/components/user-info-list.hbs
@@ -1,8 +1,8 @@
 <ul class="user-info-list">
-  {{#each users as |user|}}
+  {{#each @users as |user|}}
     <li class="user-info-item">
       <UserInfo @user={{user}}>
-        <div>{{cakeday-date user.cakedate isBirthday=isBirthday}}</div>
+        <div>{{cakeday-date user.cakedate isBirthday=@isBirthday}}</div>
       </UserInfo>
     </li>
   {{else}}

--- a/assets/javascripts/discourse/routes/cakeday-anniversaries-index.js
+++ b/assets/javascripts/discourse/routes/cakeday-anniversaries-index.js
@@ -1,7 +1,10 @@
+import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
+export default class CakedayAnniversariesIndexRoute extends DiscourseRoute {
+  @service router;
+
   beforeModel() {
-    this.replaceWith("cakeday.anniversaries.today");
-  },
-});
+    this.router.replaceWith("cakeday.anniversaries.today");
+  }
+}

--- a/assets/javascripts/discourse/routes/cakeday-anniversaries.js
+++ b/assets/javascripts/discourse/routes/cakeday-anniversaries.js
@@ -1,14 +1,20 @@
-import I18n from "I18n";
+import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class CakedayAnniversariesRoute extends DiscourseRoute {
+  @service router;
+
   beforeModel() {
     if (!this.siteSettings.private_cakeday_enabled) {
-      this.transitionTo("unknown", window.location.pathname.replace(/^\//, ""));
+      this.router.transitionTo(
+        "unknown",
+        window.location.pathname.replace(/^\//, "")
+      );
     }
-  },
+  }
 
   titleToken() {
-    return I18n.t("anniversaries.title");
-  },
-});
+    return i18n("anniversaries.title");
+  }
+}

--- a/assets/javascripts/discourse/routes/cakeday-birthdays-index.js
+++ b/assets/javascripts/discourse/routes/cakeday-birthdays-index.js
@@ -1,7 +1,10 @@
+import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
+export default class CakedayBirthdaysIndexRoute extends DiscourseRoute {
+  @service router;
+
   beforeModel() {
-    this.replaceWith("cakeday.birthdays.today");
-  },
-});
+    this.router.replaceWith("cakeday.birthdays.today");
+  }
+}

--- a/assets/javascripts/discourse/routes/cakeday-birthdays.js
+++ b/assets/javascripts/discourse/routes/cakeday-birthdays.js
@@ -1,14 +1,20 @@
-import I18n from "I18n";
+import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class CakedayBirthdaysRoute extends DiscourseRoute {
+  @service router;
+
   beforeModel() {
     if (!this.siteSettings.private_cakeday_birthday_enabled) {
-      this.transitionTo("unknown", window.location.pathname.replace(/^\//, ""));
+      this.router.transitionTo(
+        "unknown",
+        window.location.pathname.replace(/^\//, "")
+      );
     }
-  },
+  }
 
   titleToken() {
-    return I18n.t("birthdays.title");
-  },
-});
+    return i18n("birthdays.title");
+  }
+}


### PR DESCRIPTION
## Summary
Three defects broke the cakeday pages on current Discourse:

- **Navigation crash:** routes used the removed Ember `Route#replaceWith` / `Route#transitionTo`, so the index/guard routes threw `this.replaceWith is not a function` and rendered the Discourse error page when navigating between Anniversaries and Birthdays. Now inject the `router` service and use `this.router.*` (converted to class syntax; `I18n` → `discourse-i18n`).
- **Empty lists:** `UserInfoList` is a template-only component but read its arguments as bare `users` / `isBirthday`. Under strict Glimmer semantics these resolve to nothing, so every list rendered the empty branch. Now uses `@users` / `@isBirthday`.
- **Infinite load-more loop:** `BirthdaysController` counted `total` before applying the non-staff `show_birthday_to_be_celebrated` visibility filter, so `total_rows_birthdays` disagreed with the returned rows and the client `LoadMore` looped forever. Now restricts the user scope before `cakedays_by` counts/paginates.

## Test plan
- [ ] Logged-in staff: `/cakeday/birthdays/today` and `/cakeday/anniversaries/today` list users
- [ ] Logged-in non-staff: only opted-in birthdays show; empty state renders without a load-more loop
- [ ] Click back and forth between Birthdays/Anniversaries — no error page